### PR TITLE
fix readme for official-package

### DIFF
--- a/official-package/README.md
+++ b/official-package/README.md
@@ -234,8 +234,6 @@ curl -s -o ./iam-role.yaml "https://raw.githubusercontent.com/crowdstrike/aws-ss
 
 If you want to use Secrets Manager as the secret backend, replace `ParameterStore` with `SecretsManager`.
 
-```bash
-
 </details>
 
 <details> <summary>Using the AWS CLI</summary>


### PR DESCRIPTION
- simple fix for wrong open code bloc in README for official-package.
  - before : 
![Screenshot 2024-02-28 at 15 20 41](https://github.com/CrowdStrike/aws-ssm-distributor/assets/33237270/5fc86c99-f231-4460-bfbe-8f98113c3034)

  - after : 
![Screenshot 2024-02-28 at 15 21 31](https://github.com/CrowdStrike/aws-ssm-distributor/assets/33237270/5069bb04-0b4f-4e25-85c8-9cd9adaa180d)

